### PR TITLE
Show publishes under Pipeline Step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# ---- ignore special files written during config setup
+/tk-metadata/
+
+# Byte-compiled / optimized / DLL files
 *.py[cod]
 
 # C extensions


### PR DESCRIPTION
Given the following configuration for Nuke inside `tk-multi-loader2.yml` and if there are *many tasks* with the same Pipeline Step
```yaml
entities:
  - caption: Shots
    entity_type: Task
    filters:
    - [project, is, '{context.project}']
    - [entity, type_is, Shot]
    hierarchy: [entity.Shot.sg_sequence, entity, step]  # <-- Many (lighting) tasks will come under the same Pipeline Step (Lighting)
```
<details>
<summary>Click to for full Nuke example</summary><p>

```yaml
settings.tk-multi-loader2.nuke:
  actions_hook: '{config}/tk-multi-loader2/tk-nuke_actions.py'
  action_mappings:
    Alembic Cache: [read_node]
    FBX Camera: [camera_node]
    Flame Render: [read_node]
    Flame Quicktime: [read_node]
    Image: [read_node]
    Movie: [read_node]
    Nuke Script: [script_import]
    Photoshop Image: [read_node]
    Rendered Image: [read_node]
    Texture: [read_node]
  entities:
  - caption: Assets
    entity_type: Task
    filters:
    - [project, is, '{context.project}']
    - [entity, type_is, Asset]
    hierarchy: [entity.Asset.sg_asset_type, entity, step]
  - caption: Shots
    entity_type: Task
    filters:
    - [project, is, '{context.project}']
    - [entity, type_is, Shot]
    hierarchy: [entity.Shot.sg_sequence, entity, step]
  - caption: My Tasks
    entity_type: Task
    filters:
    - [task_assignees, is, '{context.user}']
    - [project, is, '{context.project}']
    hierarchy: [entity, content]
  publish_filters: [["sg_status_list", "is_not", null]]
  location: "@apps.tk-multi-loader2.location"
```
</p></details>

Have the loader be able to load `PublishedFile` based off `task.Task.step` when browsing using the hierarchy view for `Task`.

![SG_Loader_step](https://user-images.githubusercontent.com/9294702/62782686-ab284980-bab2-11e9-9bdb-2d1b74ba4a0e.gif)

- [x] Hierarchy leaves can be unique ~~(new `info.yml` setting)~~ see https://github.com/wwfxuk/tk-framework-shotgunutils/pull/2
  - [x] If many tasks share the same hierarchy leaf, the `PublishedFile` found will be an `or` of those tasks
- [x] Clicking on a `Step` if it is not a leaf will also show all `PublishedFile` that has matching `task.Task.step`

To Do before merge:

- [x]  Merge https://github.com/wwfxuk/tk-framework-shotgunutils/pull/1 and https://github.com/wwfxuk/tk-framework-shotgunutils/pull/2 as WWFX releases
- [ ] Document about the Data Handler hierarchy logic somewhere







